### PR TITLE
fix: use absolute paths in k6 scripts for SSH execution

### DIFF
--- a/monitoring/k6/run-all-tests.sh
+++ b/monitoring/k6/run-all-tests.sh
@@ -13,13 +13,17 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
+# Detectar directorio del proyecto (ajustar según estructura)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
 # Configuración
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-RESULTS_DIR="monitoring/k6/results/${TIMESTAMP}"
-K6_DIR="monitoring/k6"
+RESULTS_DIR="${PROJECT_DIR}/monitoring/k6/results/${TIMESTAMP}"
+K6_DIR="${PROJECT_DIR}/monitoring/k6"
 
 # Navegar al directorio del proyecto
-cd "$(dirname "$0")/../.."
+cd "$PROJECT_DIR"
 
 # Crear directorio de resultados
 mkdir -p "$RESULTS_DIR"

--- a/monitoring/k6/run-single-test.sh
+++ b/monitoring/k6/run-single-test.sh
@@ -6,14 +6,18 @@
 
 set -e
 
+# Detectar directorio del proyecto
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
 # Configuración
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-TEST_FILE=${1:-monitoring/k6/load-test-landing.js}
+TEST_FILE=${1:-${PROJECT_DIR}/monitoring/k6/load-test-landing.js}
 TEST_NAME=$(basename "$TEST_FILE" .js)
-RESULTS_DIR="monitoring/k6/results"
+RESULTS_DIR="${PROJECT_DIR}/monitoring/k6/results"
 
 # Navegar al directorio del proyecto
-cd "$(dirname "$0")/../.."
+cd "$PROJECT_DIR"
 
 # Crear directorio de resultados
 mkdir -p "$RESULTS_DIR"


### PR DESCRIPTION
- Replace relative paths with absolute path detection
- Use BASH_SOURCE and pwd to get correct PROJECT_DIR
- Prevents 'no such file or directory' errors when running via SSH
- Ensures results directory is created correctly

Fixes: tee/getwd errors in remote execution workflow